### PR TITLE
adapt testsuite to use already installed catalog source for OLM tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ OPERATOR_PROJECT_DIR?=$(E2E_SUITE_PROJECT_DIR)/apicurio-registry-operator
 OPERATOR_IMAGE?=quay.io/apicurio/apicurio-registry-operator:1.0.0-dev
 
 # olm variables
-export E2E_OLM_PACKAGE_MANIFEST_NAME=apicurio-registry-operator
+OLM_PACKAGE_MANIFEST_NAME?=apicurio-registry-operator
+export E2E_OLM_PACKAGE_MANIFEST_NAME=$(OLM_PACKAGE_MANIFEST_NAME)
 # OLM Channel ommited, default channel will be used
 # OLM_CHANNEL?=apicurio-registry-2.x
 # export E2E_OLM_CHANNEL=$(OLM_CHANNEL)

--- a/scripts/test-kube-lp-tests.sh
+++ b/scripts/test-kube-lp-tests.sh
@@ -1,0 +1,5 @@
+
+make kind-start kind-setup-olm
+
+E2E_OLM_USE_DEFAULT_CATALOG_SOURCE=operatorhubio-catalog \
+ OLM_PACKAGE_MANIFEST_NAME=apicurio-registry make run-operator-tests

--- a/testsuite/olm/multinamespace/suite_test.go
+++ b/testsuite/olm/multinamespace/suite_test.go
@@ -42,7 +42,7 @@ var _ = BeforeSuite(func(done Done) {
 
 var _ = AfterSuite(func() {
 
-	olm.UninstallOperatorOLM(suiteCtx, olminfo)
+	olm.UninstallOperatorOLM(suiteCtx, utils.OLMClusterWideOperatorsNamespace, true, olminfo)
 
 	suite.TearDownSuite(suiteCtx)
 

--- a/testsuite/olm/singlenamespace/suite_test.go
+++ b/testsuite/olm/singlenamespace/suite_test.go
@@ -44,7 +44,7 @@ var _ = BeforeSuite(func(done Done) {
 
 var _ = AfterSuite(func() {
 
-	olm.UninstallOperatorOLM(suiteCtx, olminfo)
+	olm.UninstallOperatorOLM(suiteCtx, operatorNamespace, false, olminfo)
 
 	suite.TearDownSuite(suiteCtx)
 

--- a/testsuite/utils/constants.go
+++ b/testsuite/utils/constants.go
@@ -17,10 +17,12 @@ const (
 	convertersURLEnvVar             = "E2E_CONVERTERS_URL"
 	convertersDistroSha512SumEnvVar = "E2E_CONVERTERS_SHA512SUM"
 
+	oLMUseDefaultCatalogSourceEnvVar       = "E2E_OLM_USE_DEFAULT_CATALOG_SOURCE"       //optional
 	oLMCatalogSourceImageEnvVar            = "E2E_OLM_CATALOG_SOURCE_IMAGE"             //mandatory env var for olm tests
 	oLMCatalogSourceNamespaceEnvVar        = "E2E_OLM_CATALOG_SOURCE_NAMESPACE"         //mandatory env var for olm tests
 	oLMApicurioPackageManifestNameEnvVar   = "E2E_OLM_PACKAGE_MANIFEST_NAME"            //mandatory env var for olm tests
 	oLMApicurioChannelNameEnvVar           = "E2E_OLM_CHANNEL"                          //mandatory env var for olm tests
+	oLMApicurioCSVEnvVar                   = "E2E_OLM_CSV"                              //optional
 	oLMClusterWideOperatorsNamespaceEnvVar = "E2E_OLM_CLUSTER_WIDE_OPERATORS_NAMESPACE" //mandatory env var for olm tests
 
 	oLMUpgradeChannelEnvVar             = "E2E_OLM_UPGRADE_CHANNEL"
@@ -67,6 +69,9 @@ var ApicurioTestsProfile string = os.Getenv(apicurioTestsProfileEnvVar)
 //StrimziOperatorBundlePath value of StrimziOperatorBundlePathEnvVar
 var StrimziOperatorBundlePath string = os.Getenv(strimziOperatorBundlePathEnvVar)
 
+//OLMUseDefaultCatalogSource value of oLMUseDefaultCatalogSourceEnvVar
+var OLMUseDefaultCatalogSource string = os.Getenv(oLMUseDefaultCatalogSourceEnvVar)
+
 //OLMCatalogSourceNamespace value of OLMCatalogSourceNamespaceEnvVar
 var OLMCatalogSourceNamespace string = os.Getenv(oLMCatalogSourceNamespaceEnvVar)
 
@@ -75,6 +80,9 @@ var OLMApicurioPackageManifestName string = os.Getenv(oLMApicurioPackageManifest
 
 //OLMApicurioChannelName value of oLMApicurioChannelNameEnvVar
 var OLMApicurioChannelName string = os.Getenv(oLMApicurioChannelNameEnvVar)
+
+//OLMApicurioCSV value of oLMApicurioCSVEnvVar
+var OLMApicurioCSV string = os.Getenv(oLMApicurioCSVEnvVar)
 
 //OLMClusterWideOperatorsNamespace value of OLMClusterWideOperatorsNamespaceEnvVar
 var OLMClusterWideOperatorsNamespace string = os.Getenv(oLMClusterWideOperatorsNamespaceEnvVar)

--- a/testsuite/utils/kafkasql/kafkasql.go
+++ b/testsuite/utils/kafkasql/kafkasql.go
@@ -437,7 +437,7 @@ func deployStrimziOperator(clientset *kubernetes.Clientset, namespace string) bo
 	kubernetescli.Execute("create", "-f", bundlePath, "-n", namespace)
 
 	// sh("oc wait deployment/strimzi-cluster-operator --for condition=available --timeout=180s")
-	timeout := 120 * time.Second
+	timeout := 180 * time.Second
 	log.Info("Waiting for strimzi operator to be ready ", "timeout", timeout)
 	err = wait.Poll(utils.APIPollInterval, timeout, func() (bool, error) {
 		od, err := clientset.AppsV1().Deployments(namespace).Get(context.TODO(), "strimzi-cluster-operator", metav1.GetOptions{})


### PR DESCRIPTION
This is work in preparation to make easier to run operator tests with olm tests in kubernetes and openshift

The script `scripts/test-kube-lp-tests.sh` is an example of what we will need for openshift

@obabec FYI